### PR TITLE
Enable aarch64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ SOURCES = \
 	token_rewriter \
 	token
 
-CPP_FILES = $(foreach source,$(SOURCES),$(source).cpp)
-HPP_FILES = $(foreach source,$(SOURCES),$(source).hpp)
+CPP_FILES = $(addsuffix .cpp,$(SOURCES))
+HPP_FILES = $(addsuffix .hpp,$(SOURCES))
 HPP_FILES += token_ids.hpp
-O_FILES = $(foreach source,$(SOURCES),$(source).$(O))
+O_FILES = $(addsuffix .$(O),$(SOURCES))
 STATIC_LIB = libruby_parser_cpp.$(A)
 
 # Codegen

--- a/codegen/build.mk
+++ b/codegen/build.mk
@@ -59,9 +59,8 @@ codegen/merge-headers:
 	chmod +x codegen/merge-headers
 CLEAN += codegen/merge-headers
 
-# A literal space.
-space :=
-space +=
+empty :=
+space := $(empty) $(empty)
 
 # Joins elements of the list in arg 2 with the given separator.
 #   1. Element separator.

--- a/ruby-parser-cpp/src/decoder.rs
+++ b/ruby-parser-cpp/src/decoder.rs
@@ -1,4 +1,5 @@
 #[allow(unused_imports)]
+use std::os::raw::{c_char};
 use crate::{blob_type, bytes::ByteListBlob, string::StringBlob};
 use lib_ruby_parser::source::{DecoderResult, InputError};
 
@@ -73,7 +74,7 @@ pub extern "C" fn lib_ruby_parser__test__always_ok_decoder(output: *const u8) ->
         drop(String::from(encoding));
         drop(Vec::<u8>::from(input));
         // and return given output
-        let output = unsafe { std::ffi::CStr::from_ptr(state as *const i8) }
+        let output = unsafe { std::ffi::CStr::from_ptr(state as *const c_char) }
             .to_str()
             .unwrap();
         DecoderResultBlob::from(DecoderResult::Ok(output.as_bytes().to_vec()))
@@ -97,7 +98,7 @@ pub extern "C" fn lib_ruby_parser__test__always_err_decoder(output: *const u8) -
         drop(String::from(encoding));
         drop(Vec::<u8>::from(input));
         // and return given output
-        let output = unsafe { std::ffi::CStr::from_ptr(state as *const i8) }
+        let output = unsafe { std::ffi::CStr::from_ptr(state as *const c_char) }
             .to_str()
             .unwrap();
         DecoderResultBlob::from(DecoderResult::Err(InputError::DecodingError(

--- a/ruby-parser-cpp/src/diagnostic.rs
+++ b/ruby-parser-cpp/src/diagnostic.rs
@@ -1,3 +1,4 @@
+use std::os::raw::{c_char};
 use crate::blob_type;
 #[allow(unused_imports)]
 use crate::message::DiagnosticMessageBlob;
@@ -42,7 +43,7 @@ pub extern "C" fn LIB_RUBY_PARSER_drop_diagnostic_list(diagnostic_list: *mut Vec
 pub extern "C" fn LIB_RUBY_PARSER_render_diagnostic(
     diagnostic: *const Diagnostic,
     input: *const DecodedInput,
-) -> *mut i8 {
+) -> *mut c_char {
     let diagnostic = unsafe { diagnostic.as_ref().unwrap() };
     let input = unsafe { input.as_ref().unwrap() };
     let rendered = diagnostic.render(input).unwrap();

--- a/ruby-parser-cpp/src/loc.rs
+++ b/ruby-parser-cpp/src/loc.rs
@@ -1,3 +1,4 @@
+use std::os::raw::{c_char};
 use crate::blob_type;
 use lib_ruby_parser::source::DecodedInput;
 #[allow(unused_imports)]
@@ -27,7 +28,7 @@ pub extern "C" fn lib_ruby_parser__test__make_some_loc(begin: usize, end: usize)
 pub extern "C" fn LIB_RUBY_PARSER_loc_source(
     loc: *const Loc,
     input: *const DecodedInput,
-) -> *mut i8 {
+) -> *mut c_char {
     let loc = unsafe { loc.as_ref().unwrap() };
     let input = unsafe { input.as_ref().unwrap() };
     let source = loc.source(input).unwrap();

--- a/ruby-parser-cpp/src/string.rs
+++ b/ruby-parser-cpp/src/string.rs
@@ -1,4 +1,5 @@
 use crate::blob_type;
+use std::os::raw::{c_char};
 
 blob_type!(StringBlob, String);
 blob_type!(MaybeStringBlob, Option<String>);
@@ -10,7 +11,7 @@ pub extern "C" fn LIB_RUBY_PARSER_new_string_owned(ptr: *mut u8, len: usize) -> 
 }
 
 #[no_mangle]
-pub extern "C" fn LIB_RUBY_PARSER_new_string_from_cstr(ptr: *const i8) -> StringBlob {
+pub extern "C" fn LIB_RUBY_PARSER_new_string_from_cstr(ptr: *const c_char) -> StringBlob {
     let s = unsafe { std::ffi::CStr::from_ptr(ptr) };
     StringBlob::from(s.to_str().unwrap_or_default().to_owned())
 }

--- a/ruby-parser-cpp/src/token.rs
+++ b/ruby-parser-cpp/src/token.rs
@@ -1,3 +1,4 @@
+use std::os::raw::{c_char};
 use crate::blob_type;
 #[allow(unused_imports)]
 use lib_ruby_parser::{Bytes, LexState, Lexer, Loc, Token};
@@ -29,7 +30,7 @@ pub extern "C" fn lib_ruby_parser__test__make_token_eq(
 }
 
 #[no_mangle]
-pub extern "C" fn LIB_RUBY_PARSER_token_name(token: *const Token) -> *mut i8 {
+pub extern "C" fn LIB_RUBY_PARSER_token_name(token: *const Token) -> *mut c_char {
     let token = unsafe { token.as_ref().unwrap() };
     let token_name = token.token_name();
     std::ffi::CString::new(token_name).unwrap().into_raw()

--- a/scripts/targets/aarch64-apple-darwin.mk
+++ b/scripts/targets/aarch64-apple-darwin.mk
@@ -1,0 +1,38 @@
+$(info Compiling aarch64-apple-darwin target)
+
+O = o
+A = a
+EXE =
+
+STATIC_LIB_FILE = libruby_parser_cpp.$(A)
+LIST_DEPS = otool -L
+
+CXXFLAGS += -std=c++17 -Wall -Wextra -Wpedantic -Weverything -g
+# but disable -Wpadded, we inherit Rust layouts
+CXXFLAGS += -Wno-padded
+# ignore documentation, it has examples of syntax errors on purpose
+CXXFLAGS += -Wno-documentation-unknown-command
+# ignore C++98 compatibility
+CXXFLAGS += -Wno-c++98-compat -Wno-c++98-compat-pedantic
+# ignore __ in function/macro names
+CXXFLAGS += -Wno-reserved-macro-identifier -Wno-reserved-identifier
+
+ifeq ($(BUILD_ENV), debug)
+CXXFLAGS += -O0
+else
+CXXFLAGS += -O3
+endif
+
+define add_to_lib
+$(AR) r $(1) $(2)
+endef
+
+define build_cxx_obj
+$(CXX) $(1) $(CXXFLAGS) -c -o $(2)
+endef
+
+define build_cxx_exe
+$(CXX) $(1) $(CXXFLAGS) -o $(2)
+endef
+
+BENCHMARK_RUNNER_ASSET_NAME = rust-parser-aarch64-apple-darwin

--- a/scripts/targets/aarch64-unknown-linux-gnu.mk
+++ b/scripts/targets/aarch64-unknown-linux-gnu.mk
@@ -1,0 +1,30 @@
+$(info Compiling aarch64-unknown-linux-gnu target)
+
+O = o
+A = a
+EXE =
+
+STATIC_LIB_FILE = libruby_parser_cpp.$(A)
+LIST_DEPS = ldd
+
+CXXFLAGS += -std=c++17 -Wall -Wextra -g -fPIC
+
+ifeq ($(BUILD_ENV), debug)
+CXXFLAGS += -O0
+else
+CXXFLAGS += -O3
+endif
+
+define add_to_lib
+$(AR) r $(1) $(2)
+endef
+
+define build_cxx_obj
+$(CXX) $(1) $(CXXFLAGS) -c -o $(2)
+endef
+
+define build_cxx_exe
+$(CXX) $(1) $(CXXFLAGS) -lpthread -ldl -lm -o $(2)
+endef
+
+BENCHMARK_RUNNER_ASSET_NAME = rust-parser-aarch64-unknown-linux-gnu


### PR DESCRIPTION
I've been building using these changes and it seems to work as expected in Debian Bullseye, aarch64.

Changes:

- [`join-with`](https://github.com/lib-ruby-parser/cpp-bindings/commit/7f916737e6f481185c7f2505b2ae318fce925f39): I couldn't trace down _precisely_ what differed about my environment that caused join-with not to work, but I did try a couple of different approaches and found that with a few modifications it would work as expected. I'll be curious to see if any portability in CI or other platforms was lost, but I am not expecting it to have been.
- [`c_char`](https://github.com/lib-ruby-parser/cpp-bindings/commit/9f5fd5d10482532003ff55b01acf77dc23c07b9e): `c_char` is aliased so it works on AMD and ARM platforms, so I've updated some source to use that instead of `i8`
- Adds linux and darwin target files. I haven't tested the Darwin one yet—I can remove it if its premature, but I'd really like to help support darwin arm64 as well.

### Note: I have not added these targets to the build/release matrix.